### PR TITLE
强化克脑优化

### DIFF
--- a/Enemies/Bosses/BrainEx.cs
+++ b/Enemies/Bosses/BrainEx.cs
@@ -67,7 +67,7 @@ namespace Starvers.Enemies.Bosses
 			#region AdjustMoving
 			if (ProjActing.State == BossState.BrainBloodDropping)
 			{
-				Moving.Offset = new Vector2(0, -16 * 25);
+				Moving.Offset = new Vector2(0, -16 * 50);
 				Moving.MaxSpeed = 40;
 				Moving.WarpingInterval = null;
 			}
@@ -154,7 +154,7 @@ namespace Starvers.Enemies.Bosses
 					}
 				case BossState.EllipseShot:
 					{
-						var machine = new EllipseShot(this, ProjectileID.DD2DrakinShot, ProjectileID.DD2DrakinShot)
+						var machine = new EllipseShot(this, ProjectileID.BloodShot, ProjectileID.BloodShot)
 						{
 							Rotation = Rand.NextAngle(),
 							RotationSpeed = Math.PI / 6 / 60,
@@ -164,7 +164,7 @@ namespace Starvers.Enemies.Bosses
 							AxisA = 16 * 6,
 							AxisB = 16 * 10,
 						};
-						machine.Linked = new EllipseShot(this, ProjectileID.NebulaBolt)
+						machine.Linked = new EllipseShot(this, ProjectileID.BloodNautilusShot)
 						{
 							Rotation = machine.Rotation,
 							RotationSpeed = Math.PI / 6 / 60,
@@ -188,7 +188,7 @@ namespace Starvers.Enemies.Bosses
 								Defense = 1500,
 								LifeMax = 1000
 							},
-							Radium = 16 * 7.5f,
+							Radium = 16 * 6f,
 							Count = 5,
 							AngleBegin = angleMid - Math.PI / 4,
 							AngleEnd = angleMid + Math.PI / 4,
@@ -201,34 +201,17 @@ namespace Starvers.Enemies.Bosses
 						{
 							ServantData = new NPCData
 							{
-								ID = NPCID.SeekerHead,
-								Defense = 1500,
-								LifeMax = 1000
-							},
-							Radium = 16 * 7.5f,
-							Count = 5,
-							AngleBegin = angleMid - Math.PI / 4,
-							AngleEnd = angleMid + Math.PI / 4,
-							TotalTime = 60 * 3 * 3,
-							Interval = 180,
-							SummonDelay = 60 * 1,
-							ServantSpeed = 4f
-						};
-						machine.Linked.Linked = new SummonServants(this)
-						{
-							ServantData = new NPCData
-							{
 								ID = NPCID.BloodSquid,
 								Defense = 500,
 								LifeMax = 750
 							},
-							Radium = 16 * 7.5f,
+							Radium = 16 * 6f,
 							Count = 5,
 							AngleBegin = angleMid - Math.PI / 4,
 							AngleEnd = angleMid + Math.PI / 4,
 							TotalTime = 60 * 3 * 3,
 							Interval = 180,
-							SummonDelay = 60 * 2,
+							SummonDelay = 90,
 							ServantSpeed = 4f
 						};
 						return machine;
@@ -239,8 +222,8 @@ namespace Starvers.Enemies.Bosses
 						{
 							ProjIDs = new int[] { ProjectileID.DeathLaser },
 							Damage = 55,
-							AccumulationTime = 60 * 12,
-							HitDuration = 60 * 9,
+							AccumulationTime = 60 * 6,
+							HitDuration = 60 * 2,
 							HitRadius = 16 * 80,
 							UpingSpeed = 2.4f
 						};
@@ -286,15 +269,15 @@ namespace Starvers.Enemies.Bosses
 						return new BrainBloodDropping(this)
 						{
 							Damage = 55,
-							DroppingInterval = 6,
-							DroppingWidth = 16 * 90,
+							DroppingInterval = 2,
+							DroppingWidth = 16 * 120,
 							TotalTime = 60 * 10,
 							DroppingSpeed = 14
 						};
 					}
 				case BossState.EllipseShot:
 					{
-						var machine = new EllipseShot(this, ProjectileID.DD2DrakinShot, ProjectileID.DD2DrakinShot)
+						var machine = new EllipseShot(this, ProjectileID.BloodShot, ProjectileID.BloodShot)
 						{
 							Rotation = Rand.NextAngle(),
 							RotationSpeed = Math.PI / 6 / 60,
@@ -305,7 +288,7 @@ namespace Starvers.Enemies.Bosses
 							AxisA = 16 * 6,
 							AxisB = 16 * 10,
 						};
-						machine.Linked = new EllipseShot(this, ProjectileID.DD2DrakinShot)
+						machine.Linked = new EllipseShot(this, ProjectileID.BloodNautilusShot)
 						{
 							Rotation = machine.Rotation + Math.PI / 2,
 							RotationSpeed = Math.PI / 6 / 60,
@@ -330,7 +313,7 @@ namespace Starvers.Enemies.Bosses
 								Defense = 1500,
 								LifeMax = 2500
 							},
-							Radium = 16 * 7.5f,
+							Radium = 16 * 6f,
 							Count = 5,
 							AngleBegin = angleMid - Math.PI / 4,
 							AngleEnd = angleMid + Math.PI / 4,
@@ -343,34 +326,17 @@ namespace Starvers.Enemies.Bosses
 						{
 							ServantData = new NPCData
 							{
-								ID = NPCID.SeekerHead,
-								Defense = 2000,
-								LifeMax = 5000
-							},
-							Radium = 16 * 7.5f,
-							Count = 5,
-							AngleBegin = angleMid - Math.PI / 4,
-							AngleEnd = angleMid + Math.PI / 4,
-							TotalTime = 60 * 3 * 2,
-							Interval = 180,
-							SummonDelay = 60 * 1,
-							ServantSpeed = 9f
-						};
-						machine.Linked.Linked = new SummonServants(this)
-						{
-							ServantData = new NPCData
-							{
 								ID = NPCID.BloodSquid,
 								Defense = 100,
 								LifeMax = 1500
 							},
-							Radium = 16 * 7.5f,
+							Radium = 16 * 6f,
 							Count = 5,
 							AngleBegin = angleMid - Math.PI / 4,
 							AngleEnd = angleMid + Math.PI / 4,
 							TotalTime = 60 * 3 * 2,
 							Interval = 180,
-							SummonDelay = 60 * 2,
+							SummonDelay = 90,
 							ServantSpeed = 9f
 						};
 						return machine;
@@ -381,8 +347,8 @@ namespace Starvers.Enemies.Bosses
 						{
 							ProjIDs = new int[] { ProjectileID.DeathLaser },
 							Damage = 55,
-							AccumulationTime = 60 * 12,
-							HitDuration = 60 * 9,
+							AccumulationTime = 60 * 6,
+							HitDuration = 60 * 2,
 							HitRadius = 16 * 80,
 							UpingSpeed = 2.4f
 						};

--- a/Enemies/Bosses/StarverBoss.States.cs
+++ b/Enemies/Bosses/StarverBoss.States.cs
@@ -54,7 +54,6 @@ namespace Starvers.Enemies.Bosses
 			}
 		}
 		#endregion
-		#region Machines
 		#region EyeSharknado
 		protected class EyeSharknadoMachine : BossStateMachine
 		{
@@ -812,11 +811,11 @@ namespace Starvers.Enemies.Bosses
 
 			public BrainBloodDropping(StarverBoss boss) : base(BossState.BrainBloodDropping, boss)
 			{
-				TotalTime = 10 * 60;
-				DroppingInterval = 10;
+				TotalTime = 8 * 60;
+				DroppingInterval = 3;
 				Damage = 35;
-				DroppingWidth = 16 * 90;
-				DroppingSpeed = 9;
+				DroppingWidth = 16 * 150;
+				DroppingSpeed = 12;
 			}
 
 			protected override void InternalUpdate()
@@ -1094,9 +1093,9 @@ namespace Starvers.Enemies.Bosses
 					}
 					for (int i = 0; i < hitPoints.Length; i++)
 					{
-						Boss.ProjCircle(hitPoints[i], 16 * 10, 0.1f, ProjectileID.DesertDjinnCurse, 8, 65);
+						Boss.ProjCircle(hitPoints[i], 16 * 8, 0.1f, ProjectileID.CrimsonSpray, 36, -1);
 					}
-					Boss.ProjCircle(Boss.Center, 16 * 25, 0.1f, ProjectileID.BloodNautilusTears, 16, -1);
+					Boss.ProjCircle(Boss.Center, 16 * 8, 0.1f, ProjectileID.CrimsonSpray, 36, -1);
 					Boss.ProjCircle(Boss.Center, 16 * 01, 4.5f, ProjectileID.DeathLaser, 120, 120);
 				}
 				else if (Timer - AccumulationTime < HitDuration)
@@ -1185,7 +1184,6 @@ namespace Starvers.Enemies.Bosses
 				}
 			}
 		}
-		#endregion
 		#endregion
 		#region Base
 		protected abstract class BossStateMachine


### PR DESCRIPTION
*血雨阶段范围和频率增大
*召唤小怪数量变少且更为集中，且不会再召唤世界哺育者
*替换弹幕，提高视觉效果

-现有的BUG：半血以后BOSS进入召唤爬行者阶段后有概率不再退出该阶段（表现为在所有爬行者死亡后立刻召唤再召唤一批爬行者，如此循环）